### PR TITLE
修复windows路径配置错误

### DIFF
--- a/preview.html
+++ b/preview.html
@@ -1136,14 +1136,45 @@ fi` : '# Git 信息已关闭'}
         // Python 配置脚本（写入 settings.json）预先 base64 编码，避免命令行引号冲突
         const CONFIG_PY_B64 = 'aW1wb3J0IGpzb24sIG9zCnAgPSBvcy5wYXRoLmV4cGFuZHVzZXIoIn4vLmNsYXVkZS9zZXR0aW5ncy5qc29uIikKcyA9IGpzb24ubG9hZChvcGVuKHApKSBpZiBvcy5wYXRoLmV4aXN0cyhwKSBlbHNlIHt9CnNbInN0YXR1c0xpbmUiXSA9IHsidHlwZSI6ICJjb21tYW5kIiwgImNvbW1hbmQiOiBvcy5wYXRoLmV4cGFuZHVzZXIoIn4vLmNsYXVkZS9zdGF0dXNsaW5lLnNoIil9Cmpzb24uZHVtcChzLCBvcGVuKHAsICJ3IiksIGluZGVudD0yLCBlbnN1cmVfYXNjaWk9RmFsc2UpCg==';
 
-        function copyInstallCmd() {
+function copyInstallCmd() {
             const script = generateScript();
-            // 两段 base64：脚本本体 + 配置脚本，命令里完全没有双引号，彻底避免 shell 解析问题
+            // 编码脚本本体
             const b64 = btoa(unescape(encodeURIComponent(script)));
+            
+            /**
+             * 关键修复逻辑：
+             * 1. 使用 Python 检测路径分隔符
+             * 2. 如果是 Windows (\)，则将 C:\ 转换为 /c/ 并将 \ 替换为 /
+             * 3. 强制在 command 前加上 'bash ' 以确保正确解析
+             */
+            const CONFIG_PY = `
+import json, os
+p = os.path.expanduser("~/.claude/settings.json")
+s = json.load(open(p)) if os.path.exists(p) else {}
+raw_path = os.path.expanduser("~/.claude/statusline.sh")
+# Windows 路径兼容性处理
+if "\\\\" in raw_path or (":" in raw_path and raw_path[1] == ":"):
+    # 转换为 Unix 风格: C:\\Users -> /c/Users
+    if ":" in raw_path:
+        parts = raw_path.split(":")
+        drive = parts[0].lower()
+        path = parts[1].replace("\\\\", "/")
+        final_path = f"/{drive}{path}"
+    else:
+        final_path = raw_path.replace("\\\\", "/")
+    cmd = f"bash {final_path}"
+else:
+    cmd = raw_path
+
+s["statusLine"] = {"type": "command", "command": cmd}
+json.dump(s, open(p, "w"), indent=2, ensure_ascii=False)
+`;
+            const CONFIG_PY_B64 = btoa(CONFIG_PY.trim());
+
             const command = `echo '${b64}' | base64 -d > ~/.claude/statusline.sh && chmod +x ~/.claude/statusline.sh && echo '${CONFIG_PY_B64}' | base64 -d | python3 && echo 'Statusline installed!'`;
 
+            // 复制到剪贴板逻辑
             const doCopy = (text) => {
-                // 优先用 clipboard API，file:// 下 fallback 到 execCommand
                 if (navigator.clipboard && navigator.clipboard.writeText) {
                     navigator.clipboard.writeText(text).then(onCopied).catch(() => fallbackCopy(text));
                 } else {
@@ -1175,7 +1206,7 @@ fi` : '# Git 信息已关闭'}
             doCopy(command);
         }
 
-        // ===== 初始化 =====
+        // 初始化
         renderOptions();
         updatePreview();
     </script>


### PR DESCRIPTION
### 🚀 Fix: 解决 Windows 环境下状态栏不显示的问题

#### 🛠 问题描述 (Issue)

在 Windows 环境下使用 Claude Code 时，状态栏无法正常显示。

**根因分析：**
配置中的 `statusLine` 命令路径格式不兼容。

* **当前配置：** `"command": "C:\\Users\\xingr\\.claude\\statusline.sh"`
* **故障原因：** Claude Code 的底层执行环境通常为 Bash（如 Git Bash），它无法直接解析包含反斜杠 `\` 和磁盘盘符 `C:` 的 Windows 原生路径，导致该命令被识别为非法指令或找不到路径。

#### 💡 解决方案 (Solution)

将路径转换为符合 POSIX 标准的 Unix 风格路径，并显式指定通过 `bash` 解释器执行。

**关键修复逻辑：**

1. **环境自适应**：利用 Python 动态检测路径分隔符。
2. **路径重映射**：针对 Windows 环境，将磁盘挂载路径从 `C:\` 转换为 `/c/`，并将所有反斜杠 `\\` 替换为正斜杠 `/`。
3. **显式调用**：在命令前强制添加 `bash ` 前缀，确保在任何终端环境下都能正确引导执行脚本。

#### 📝 修改前后对比

* **修改前 (Broken):**
```json
"command": "C:\\Users\\xingr\\.claude\\statusline.sh"

```


* **修改后 (Fixed):**
```json
"command": "bash /c/Users/xingr/.claude/statusline.sh"

```



#### ✅ 验证结果 (Verification)

经本地测试，修改路径格式后，状态栏（Statusline）能够完美渲染输出，Token 统计与 Git 状态显示恢复正常。

---
